### PR TITLE
parser: Get type from annotation if not on attrib

### DIFF
--- a/ParseTypeScript/Parser.php
+++ b/ParseTypeScript/Parser.php
@@ -268,9 +268,12 @@ class Parser
                     $entity = end($expl);
                 }
             }
-            return $entity . $collection;
-            // var_dump($result);die;
 
+            // Attributes and annotations may be mixed. If the entity could not be find this way,
+            // check if it's still assigned through annotations
+            if (isset($entity)) {
+                return $entity . $collection;
+            }
         }
 
         $type = $type->getDocComment();

--- a/ParseTypeScript/Parser.php
+++ b/ParseTypeScript/Parser.php
@@ -271,7 +271,7 @@ class Parser
 
             // Attributes and annotations may be mixed. If the entity could not be find this way,
             // check if it's still assigned through annotations
-            if (isset($entity)) {
+            if (!empty($entity)) {
                 return $entity . $collection;
             }
         }


### PR DESCRIPTION
Para un proyecto existente estamos usando bundles ya actualizados para usar atributos, pero no hemos migrado todas las anotaciones de Doctrine a atributos aun. Así que tenemos una mezcla de ambos en algunos casos.

En el caso de las colecciones, hemos añadido atributos especiales a algunas pero manteniendo el tipo y la relación de ORM en las anotaciones, así que es incapaz de ponerle un tipo.

Con este cambio, si es incapaz de sacar el tipo de una colección por los atributos, lo intenta con las anotaciones.