### PR TITLE
Better handle nullables for frontend devs

### DIFF
--- a/ParseTypeScript/Parser.php
+++ b/ParseTypeScript/Parser.php
@@ -75,16 +75,16 @@ class Parser
 
             $type = $this->parsePhpDocForProperty($property);
 
-            $isNull = '';
+            $isNull = false;
             if (preg_match('/nullable=true/i', $property->getDocComment(), $matches)) {
-                $isNull = '?';
+                $isNull = true;
             }
 
             if (empty($isNull) && is_null($property->getType()) !== true && $property->getType()->allowsNull()) {
-                $isNull = '?';
+                $isNull = true;
             }
 
-            $this->currentInterface->properties[] = new TypeScriptProperty($property->getName() . $isNull, $type);
+            $this->currentInterface->properties[] = new TypeScriptProperty($property->getName(), $type, $isNull);
         }
 
         $this->output[] = $this->currentInterface;

--- a/ParseTypeScript/TypeScriptBaseInterface.php
+++ b/ParseTypeScript/TypeScriptBaseInterface.php
@@ -42,7 +42,7 @@ class TypeScriptBaseInterface
                 }
             }
 
-            $pieces[] = "  " . $property->name . ": " . $property->type . ";";
+            $pieces[] = '  ' . (string) $property  . ';';
         }
 
         $result = "";

--- a/ParseTypeScript/TypeScriptProperty.php
+++ b/ParseTypeScript/TypeScriptProperty.php
@@ -23,15 +23,21 @@ class TypeScriptProperty
      */
     public $type;
 
-    public function __construct(string $name, string $type = 'unknown')
+    /**
+     * @var bool
+     */
+    public $isNullable;
+
+    public function __construct(string $name, string $type = 'unknown', bool $isNullable = false)
     {
         $this->name = $name;
         $this->type = $type;
+        $this->isNullable = $isNullable;
     }
 
     public function __toString()
     {
-        return $this->name . ': ' . $this->type;
+        return $this->name . '?: ' . $this->type . ($this->isNullable ? ' | null' : '') ;
     }
 
 }


### PR DESCRIPTION
Desde frontend dicen que para valores nullables, prefieren el `|null` al ' ?:`. Debe ser mas correcto.

El `:?` se pone siempre porque es algo que se define por llamada, no por clase, así que se deja siempre por si acaso.

Comenta con Imanol para mas detalles