### PR TITLE
fix symfony 6 deprecations

### DIFF
--- a/Command/GenerateAllCommand.php
+++ b/Command/GenerateAllCommand.php
@@ -44,7 +44,7 @@ class GenerateAllCommand extends Command
 
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
         $commandInterface = $this->getApplication()->find('typescript:generate:interfaces');

--- a/Command/GenerateInterfaceCommand.php
+++ b/Command/GenerateInterfaceCommand.php
@@ -46,7 +46,7 @@ class GenerateInterfaceCommand extends Command
 
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
         $dirOutput = $input->getArgument('output');

--- a/Command/GeneratePackageCommand.php
+++ b/Command/GeneratePackageCommand.php
@@ -46,7 +46,7 @@ class GeneratePackageCommand extends Command
 
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
         $dirOutput   = $input->getArgument('output');


### PR DESCRIPTION
Añadir tipado a la respuesta de las funciones execute del bundle para que sea compatible con Symfony 6

![image](https://github.com/irontec/typescript-generator-bundle/assets/51539151/64661fa4-6d0d-4d16-8c63-f68331d7ec24)
